### PR TITLE
Download Progress On Bundle Upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .env
 .DS_Store
+
+stallion-package

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ node_modules
 dist
 .env
 .DS_Store
-
-stallion-package

--- a/scripts/prep-release.js
+++ b/scripts/prep-release.js
@@ -41,8 +41,8 @@ async function prepRelease() {
     if (process.env.NODE_ENV === "development") {
       console.log(chalk.cyan(`Linking ${rootPath} globally...`));
       try {
-        exec(`pnpm link --global`, { cwd: rootPath, stdio: 'inherit' });
-        console.log(chalk.green("Global link created successfully."));
+        exec(`cd ${rootPath} && pnpm link --global`);
+        console.log(chalk.bold.green("Global link created successfully."));
       } catch (linkError) {
         console.error(`${chalk.bold.red("Linking failed:")} ${linkError.message}`);
       }

--- a/scripts/prep-release.js
+++ b/scripts/prep-release.js
@@ -38,6 +38,7 @@ async function prepRelease() {
     // Delete the dist directory
     rimraf.sync(distPath);
     // npm pack in rootPath
+    // Link globally in development mode
     if (process.env.NODE_ENV === "development") {
       console.log(chalk.cyan(`Linking ${rootPath} globally...`));
       try {

--- a/scripts/prep-release.js
+++ b/scripts/prep-release.js
@@ -39,8 +39,13 @@ async function prepRelease() {
     rimraf.sync(distPath);
     // npm pack in rootPath
     if (process.env.NODE_ENV === "development") {
-      console.log("Linking globally...");
-      exec(`cd ${rootPath} && pnpm link --global`);
+      console.log(chalk.cyan(`Linking ${rootPath} globally...`));
+      try {
+        exec(`pnpm link --global`, { cwd: rootPath, stdio: 'inherit' });
+        console.log(chalk.green("Global link created successfully."));
+      } catch (linkError) {
+        console.error(`${chalk.bold.red("Linking failed:")} ${linkError.message}`);
+      }
     }
     console.log(chalk.bold.green("Success"));
   } catch (e) {

--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -28,7 +28,7 @@ export class ApiClient {
   async post<T>(
     url: string,
     data?: any,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig,
   ): Promise<T> {
     try {
       const response = await this.client.post<T>(url, data, config);
@@ -42,10 +42,34 @@ export class ApiClient {
   async put<T>(
     url: string,
     data?: any,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig,
   ): Promise<T> {
     try {
       const response = await this.client.put<T>(url, data, config);
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error);
+    }
+  }
+
+  // PUT request with upload progress
+  async putWithProgress<T>(
+    url: string,
+    data?: any,
+    onUploadProgress?: (percentage: number) => void,
+    config?: AxiosRequestConfig,
+  ): Promise<T> {
+    try {
+      const response = await this.client.put<T>(url, data, {
+        ...config,
+        onUploadProgress: (progressEvent) => {
+          if (onUploadProgress && progressEvent.total) {
+            const percentage =
+              (progressEvent.loaded * 100) / progressEvent.total;
+            onUploadProgress(percentage);
+          }
+        },
+      });
       return response.data;
     } catch (error) {
       throw this.handleError(error);
@@ -66,7 +90,7 @@ export class ApiClient {
   async patch<T>(
     url: string,
     data?: any,
-    config?: AxiosRequestConfig
+    config?: AxiosRequestConfig,
   ): Promise<T> {
     try {
       const response = await this.client.patch<T>(url, data, config);
@@ -83,8 +107,8 @@ export class ApiClient {
         return new Error(
           error?.response?.data?.errors?.data?.[0]?.message ||
             `API Error: ${axiosError.response.status} - ${JSON.stringify(
-              axiosError.response.data
-            )}`
+              axiosError.response.data,
+            )}`,
         );
       }
       return new Error(`API Error: ${axiosError.message}`);

--- a/src/api/api-client.ts
+++ b/src/api/api-client.ts
@@ -55,7 +55,12 @@ export class ApiClient {
   }
 
   // Upload file with progress tracking
-  putWithProgress<T>(url: string, filePath: string, onProgress?: (percentage: number) => void) {
+  putWithProgress<T>(
+    url: string,
+    filePath: string,
+    contentType: string,
+    onProgress?: (percentage: number) => void,
+  ): Promise<T> {
     const { hostname, pathname, search } = new URL(url);
     const fileSize = fs.statSync(filePath).size;
     let uploaded = 0;
@@ -72,7 +77,7 @@ export class ApiClient {
         });
       });
 
-      req.setHeader("Content-Type", "application/zip");
+      req.setHeader("Content-Type", contentType);
       req.setHeader("Content-Length", fileSize);
       req.on("error", (err: Error) => reject(this.handleError(err)));
 

--- a/src/command-line/base.command.ts
+++ b/src/command-line/base.command.ts
@@ -14,7 +14,7 @@ export abstract class BaseCommand {
 
   protected validateOptions(
     options: Record<string, any>,
-    expected: CommandOption[] = [],
+    expected: CommandOption[] = []
   ): boolean {
     const missing = expected
       .filter((opt) => {
@@ -33,7 +33,7 @@ export abstract class BaseCommand {
   async login(): Promise<boolean> {
     try {
       logger.info(
-        `Opening your browser...${os.EOL}• Visit ${ENDPOINTS.CLI_LOGIN} and enter the code:`,
+        `Opening your browser...${os.EOL}• Visit ${ENDPOINTS.CLI_LOGIN} and enter the code:`
       );
 
       opener(ENDPOINTS.CLI_LOGIN);

--- a/src/command-line/base.command.ts
+++ b/src/command-line/base.command.ts
@@ -14,7 +14,7 @@ export abstract class BaseCommand {
 
   protected validateOptions(
     options: Record<string, any>,
-    expected: CommandOption[] = []
+    expected: CommandOption[] = [],
   ): boolean {
     const missing = expected
       .filter((opt) => {
@@ -33,7 +33,7 @@ export abstract class BaseCommand {
   async login(): Promise<boolean> {
     try {
       logger.info(
-        `Opening your browser...${os.EOL}• Visit ${ENDPOINTS.CLI_LOGIN} and enter the code:`
+        `Opening your browser...${os.EOL}• Visit ${ENDPOINTS.CLI_LOGIN} and enter the code:`,
       );
 
       opener(ENDPOINTS.CLI_LOGIN);
@@ -51,7 +51,7 @@ export abstract class BaseCommand {
         id: null,
         token: token.trim(),
       });
-      await progress("Verifying login", this.verifyLogin());
+      await progress("Verifying login", () => this.verifyLogin());
 
       logger.success("Token saved successfully. Login successful.");
       return true;

--- a/src/commands/publish-bundle.command.ts
+++ b/src/commands/publish-bundle.command.ts
@@ -76,7 +76,7 @@ const expectedOptions: CommandOption[] = [
     name: "keep-artifacts",
     description: "Whether to keep the artifacts after publishing",
     required: false,
-  },
+  }
 ];
 
 @Command({
@@ -120,7 +120,7 @@ export class PublishBundleCommand extends BaseCommand {
     } = options;
 
     const contentTempRootPath = await fs.mkdtemp(
-      path.join(this.contentRootPath, "stallion-temp-"),
+      path.join(this.contentRootPath, "stallion-temp-")
     );
     this.contentRootPath = path.join(contentTempRootPath, "Stallion");
     await fs.mkdir(this.contentRootPath);
@@ -166,7 +166,7 @@ export class PublishBundleCommand extends BaseCommand {
         this.contentRootPath,
         hermesLogs,
         hermescPath,
-        sourcemap,
+        sourcemap
       );
     }
 
@@ -177,13 +177,13 @@ export class PublishBundleCommand extends BaseCommand {
 
     if (privateKey) {
       await progress(chalk.cyanBright("Signing Bundle"), () =>
-        signBundle(path.join(this.contentRootPath, "bundles"), privateKey),
+        signBundle(path.join(this.contentRootPath, "bundles"), privateKey)
       );
     }
     await progress(chalk.white("Archiving Bundle"), () =>
       createZip(
         path.join(this.contentRootPath, "bundles"),
-        contentTempRootPath,
+        contentTempRootPath
       ),
     );
     const zipPath = path.resolve(contentTempRootPath, "build.zip");
@@ -201,7 +201,7 @@ export class PublishBundleCommand extends BaseCommand {
           platform,
           releaseNote,
           ciToken,
-          updateProgress,
+          updateProgress
         ),
     );
     logger.success("Success!, Published new version");
@@ -250,7 +250,7 @@ export class PublishBundleCommand extends BaseCommand {
         throw new Error("Internal Error: invalid signed url");
       }
 
-      await client.putWithProgress(url, filePath, onProgress);
+      await client.putWithProgress(url, filePath, "application/zip", onProgress);
       return hash;
     } catch (e: any) {
       if (e.toString().includes("SignatureDoesNotMatch")) {

--- a/src/commands/release-bundle.command.ts
+++ b/src/commands/release-bundle.command.ts
@@ -87,7 +87,7 @@ export class ReleaseBundleCommand extends BaseCommand {
 
     await progress(
       chalk.cyanBright("Releasing bundle"),
-      this.releaseBundle(client, data, ciToken)
+      () => this.releaseBundle(client, data, ciToken)
     );
 
     logger.success("Bundle released successfully!");

--- a/src/commands/update-release.command.ts
+++ b/src/commands/update-release.command.ts
@@ -93,9 +93,8 @@ export class UpdateReleaseCommand extends BaseCommand {
     const client = new ApiClient(CONFIG.API.BASE_URL);
 
     try {
-      await progress(
-        chalk.white("Updating release"),
-        this.updateRelease(client, data, ciToken)
+      await progress(chalk.white("Updating release"), () =>
+        this.updateRelease(client, data, ciToken),
       );
       logger.success("Release updated successfully!");
     } catch (error) {
@@ -112,7 +111,7 @@ export class UpdateReleaseCommand extends BaseCommand {
         headers: {
           "x-ci-token": ciToken,
         },
-      }
+      },
     );
     return updateReleaseResp;
   }

--- a/src/commands/update-release.command.ts
+++ b/src/commands/update-release.command.ts
@@ -111,7 +111,7 @@ export class UpdateReleaseCommand extends BaseCommand {
         headers: {
           "x-ci-token": ciToken,
         },
-      },
+      }
     );
     return updateReleaseResp;
   }

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,13 +1,18 @@
 import * as tty from "tty";
 const ora = require("ora");
+import { noop } from "lodash";
+type ProgressUpdater = (percentage: number) => void;
 
 /**
  * Shows a progress spinner for an async operation
  * @param title The text to show while the operation is in progress
- * @param action The promise to track
+ * @param action Function that receives a progress updater callback
  * @returns The result of the promise
  */
-export function progress<T>(title: string, action: Promise<T>): Promise<T> {
+export function progress<T>(
+  title: string,
+  action: (updateProgress: ProgressUpdater) => Promise<T>,
+): Promise<T> {
   const stdoutIsTerminal = tty.isatty(1);
 
   if (stdoutIsTerminal) {
@@ -16,7 +21,11 @@ export function progress<T>(title: string, action: Promise<T>): Promise<T> {
       color: "white",
     }).start();
 
-    return action
+    const updateProgress: ProgressUpdater = (percentage: number) => {
+      spinner.text = `${title} (${percentage.toFixed(0)}%)`;
+    };
+
+    return action(updateProgress)
       .then((result) => {
         spinner.succeed();
         return result;
@@ -26,7 +35,7 @@ export function progress<T>(title: string, action: Promise<T>): Promise<T> {
         throw ex;
       });
   } else {
-    return action;
+    return action(noop);
   }
 }
 

--- a/src/utils/progress.ts
+++ b/src/utils/progress.ts
@@ -1,6 +1,7 @@
 import * as tty from "tty";
 const ora = require("ora");
 import { noop } from "lodash";
+
 type ProgressUpdater = (percentage: number) => void;
 
 /**


### PR DESCRIPTION
Changes made:
- add some try/catch on the linking step of the dev release creation script because it was failing for me without any info
- log the bundle's size before the upload begin
- created a putWithProgress method on the api client to handle the logic of progress calculation, here I'm using the https node module because it didn't work with axios, despite having an onUploadProgress option 😕
- had to change the signature of the `progress` function to track progress percentage, initially I made it receive either a promise or function, but I didn't like to have to check what type `action` is, when I could just make it be always a function and change the couple of places where progress was called. Let me know your preference
- didn't add test coverage since there were no test in the project

How it looks, uploading an actual bundle from a project I work on (yes my internet connection is slow):

https://github.com/user-attachments/assets/1df7d5aa-09cd-4f7f-ad63-69719f13db48


