### PR TITLE
fix: pin figlet to 1.8.1 and harden banner against load failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "axios": "^1.9.0",
     "chalk": "^4.1.2",
     "commander": "^13.1.0",
-    "figlet": "^1.7.0",
+    "figlet": "1.8.1",
     "gradient-string": "^2.0.2",
     "inquirer": "^12.6.1",
     "jsonwebtoken": "^9.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^13.1.0
         version: 13.1.0
       figlet:
-        specifier: ^1.7.0
+        specifier: 1.8.1
         version: 1.8.1
       gradient-string:
         specifier: ^2.0.2

--- a/src/utils/banner.ts
+++ b/src/utils/banner.ts
@@ -1,11 +1,11 @@
-import { logger } from "@utils/logger";
 import gradient from "gradient-string";
 import chalk from "chalk";
-const figlet = require("figlet");
 
 import { getVersion } from "./version";
 
-export const showBanner = async (): Promise<void> => {
+const renderFigletBanner = (): Promise<string> => {
+  const figlet = require("figlet");
+
   return new Promise((resolve, reject) => {
     figlet.text(
       "STALLION",
@@ -15,23 +15,32 @@ export const showBanner = async (): Promise<void> => {
         verticalLayout: "default",
       },
       (err: any, data: any) => {
-        if (err) {
-          reject("Something went wrong...");
+        if (err || !data) {
+          reject(err ?? new Error("figlet returned no output"));
           return;
         }
-        // Apply retro gradient to the banner
-        const gradientBanner = gradient.retro.multiline(data || "");
-        console.log(gradientBanner);
-        console.log(
-          "\n" +
-            chalk.whiteBright(
-              `⚡ Welcome to the Stallion CLI ${chalk.bold(
-                chalk.greenBright(`v${getVersion()}`)
-              )} ⚡ \n`
-            )
-        );
-        resolve();
+        resolve(data);
       }
     );
   });
+};
+
+export const showBanner = async (): Promise<void> => {
+  let banner = "STALLION";
+
+  try {
+    banner = await renderFigletBanner();
+  } catch {
+    // Decorative only — fall back to the plain wordmark.
+  }
+
+  console.log(gradient.retro.multiline(banner));
+  console.log(
+    "\n" +
+      chalk.whiteBright(
+        `⚡ Welcome to the Stallion CLI ${chalk.bold(
+          chalk.greenBright(`v${getVersion()}`)
+        )} ⚡ \n`
+      )
+  );
 };


### PR DESCRIPTION
figlet 1.9.0+ ships a broken CommonJS build (import.meta.url → undefined), so require("figlet") threw on load and killed the CLI on every command. Our ^1.7.0 range let fresh installs pull 1.11.1

Fixed two ways:
- Pinned figlet to exact 1.8.1 — no installer can reach the broken build.
- banner.ts now loads figlet lazily inside showBanner() with a plain-text fallback, so a bad banner dependency can never crash the CLI again. (The existing try/catch in index.ts couldn't help — the old top-level require threw at import time, before any handler was reachable.)